### PR TITLE
Added prefix delegation option for VPC CNI

### DIFF
--- a/example.tfvars
+++ b/example.tfvars
@@ -91,6 +91,8 @@ extra_node_role_policy_arns = []
 enable_network_policy            = true
 vpc_cni_addon_version            = null
 vpc_cni_service_account_role_arn = null
+vpc_cni_enable_prefix_delegation = true
+vpc_cni_warm_prefix_target       = 1
 coredns_addon_version            = null
 
 create_bastion           = false

--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,8 @@ module "eks" {
   enable_network_policy            = var.enable_network_policy
   vpc_cni_addon_version            = var.vpc_cni_addon_version
   vpc_cni_service_account_role_arn = var.vpc_cni_service_account_role_arn
+  vpc_cni_enable_prefix_delegation = var.vpc_cni_enable_prefix_delegation
+  vpc_cni_warm_prefix_target       = var.vpc_cni_warm_prefix_target
   coredns_addon_version            = var.coredns_addon_version
 }
 

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,3 +1,15 @@
+locals {
+  vpc_cni_env = merge(
+    var.vpc_cni_enable_prefix_delegation ? { ENABLE_PREFIX_DELEGATION = "true" } : {},
+    var.vpc_cni_enable_prefix_delegation && var.vpc_cni_warm_prefix_target > 0 ? { WARM_PREFIX_TARGET = tostring(var.vpc_cni_warm_prefix_target) } : {}
+  )
+
+  vpc_cni_config = merge(
+    var.enable_network_policy ? { enableNetworkPolicy = "true" } : {},
+    length(local.vpc_cni_env) > 0 ? { env = local.vpc_cni_env } : {}
+  )
+}
+
 resource "aws_security_group" "eks_cluster" {
   name        = "${var.name_prefix}-eks-cluster"
   description = "EKS cluster security group"
@@ -350,9 +362,7 @@ resource "aws_eks_addon" "vpc_cni" {
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 
-  configuration_values = var.enable_network_policy ? jsonencode({
-    enableNetworkPolicy = "true"
-  }) : null
+  configuration_values = length(local.vpc_cni_config) > 0 ? jsonencode(local.vpc_cni_config) : null
 
   depends_on = [
     aws_eks_cluster.main,

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,7 +1,7 @@
 locals {
   vpc_cni_env = merge(
     var.vpc_cni_enable_prefix_delegation ? { ENABLE_PREFIX_DELEGATION = "true" } : {},
-    var.vpc_cni_enable_prefix_delegation && var.vpc_cni_warm_prefix_target > 0 ? { WARM_PREFIX_TARGET = tostring(var.vpc_cni_warm_prefix_target) } : {}
+    var.vpc_cni_enable_prefix_delegation && var.vpc_cni_warm_prefix_target >= 0 ? { WARM_PREFIX_TARGET = tostring(var.vpc_cni_warm_prefix_target) } : {}
   )
 
   vpc_cni_config = merge(

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -98,6 +98,14 @@ variable "vpc_cni_service_account_role_arn" {
   type = string
 }
 
+variable "vpc_cni_enable_prefix_delegation" {
+  type = bool
+}
+
+variable "vpc_cni_warm_prefix_target" {
+  type = number
+}
+
 variable "coredns_addon_version" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -384,8 +384,8 @@ variable "vpc_cni_warm_prefix_target" {
   description = "Number of prefixes to keep warm per node when prefix delegation is enabled (0 to disable)."
   default     = 1
   validation {
-    condition     = var.vpc_cni_warm_prefix_target >= 0
-    error_message = "vpc_cni_warm_prefix_target must be 0 or greater."
+    condition     = var.vpc_cni_warm_prefix_target >= 0 && floor(var.vpc_cni_warm_prefix_target) == var.vpc_cni_warm_prefix_target
+    error_message = "vpc_cni_warm_prefix_target must be a whole number greater than or equal to 0."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -373,6 +373,22 @@ variable "vpc_cni_service_account_role_arn" {
   default     = null
 }
 
+variable "vpc_cni_enable_prefix_delegation" {
+  type        = bool
+  description = "Enable VPC CNI prefix delegation to increase pod density."
+  default     = true
+}
+
+variable "vpc_cni_warm_prefix_target" {
+  type        = number
+  description = "Number of prefixes to keep warm per node when prefix delegation is enabled (0 to disable)."
+  default     = 1
+  validation {
+    condition     = var.vpc_cni_warm_prefix_target >= 0
+    error_message = "vpc_cni_warm_prefix_target must be 0 or greater."
+  }
+}
+
 variable "coredns_addon_version" {
   type        = string
   description = "CoreDNS addon version (null to use AWS default)."


### PR DESCRIPTION
To mitigate the issue described below, a Terraform variable has been added to enable AWS VPC CNI Prefix Delegation. 

- https://github.com/nullforu/smctf-infra/issues/4

You can use the following tfvars:

```terraform
vpc_cni_enable_prefix_delegation = true
vpc_cni_warm_prefix_target       = 1
```
